### PR TITLE
Localize Date Formats

### DIFF
--- a/helpers/Csv.rb
+++ b/helpers/Csv.rb
@@ -44,6 +44,7 @@ class Csv
   def doWorkflow(options)
 
     resultsByTripId = options[:resultsByTripId]
+    groupTimeZone = options[:groupTimeZone]
 
     machineNames = []
     columnNames  = []
@@ -76,7 +77,8 @@ class Csv
           # hack for handling time
           isTimeRelated = key.match(/timestamp/) || key.match(/start_time/) || key.match(/startTime/)
           isntFalsy     = ! ( value.nil? || value == "" || value == 0 )
-          if isTimeRelated && isntFalsy then value = Time.at(value.to_i / 1000).strftime("%yy %mm %dd %Hh %Mm") end
+          if isTimeRelated && isntFalsy && groupTimeZone.nil?  then value = Time.at(value.to_i / 1000).strftime("%yy %mm %dd %Hh %Mm") end
+          if isTimeRelated && isntFalsy && !groupTimeZone.nil? then value = Time.at(value.to_i / 1000).getlocal(groupTimeZone).strftime("%yy %mm %dd %Hh %Mm") end
 
           unless indexByMachineName[machineName] # Have we seen the machine name before?
             machineNames.push machineName

--- a/routes/workflow.rb
+++ b/routes/workflow.rb
@@ -27,6 +27,13 @@ class Brockman < Sinatra::Base
     $logger.info "User #{authenticate[:name]} authenticated"
 
     #
+    # get Group settings
+    #
+    groupSettings = couch.getRequest({ :doc => 'settings', :parseJson => true })
+    groupTimeZone = groupSettings['timeZone']    
+
+
+    #
     # get workflow
     #
 
@@ -78,7 +85,8 @@ class Brockman < Sinatra::Base
     })
 
     file = csv.doWorkflow({
-      :resultsByTripId => resultsByTripId
+      :resultsByTripId => resultsByTripId,
+      :groupTimeZone => groupTimeZone
     })
 
     $logger.info "Done, returning value"


### PR DESCRIPTION
Retrieve the target Tangerine DB "settings" document and check for the existance of a timezone variable. If it exists, leverage it to adjust the formatted Date/Time values to the local context for the workflow reports.
